### PR TITLE
docs(readme): add comment about loading decorator before any others (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ within `.storybook/preview.js`:
 import { addDecorator } from '@storybook/react';
 import { withPlayroom } from 'storybook-addon-playroom';
 
-addDecorator(withPlayroom);
+addDecorator(withPlayroom); // before any other decorators
 ```
 
 See [`example`](example) for a minimal working setup.

--- a/example/.storybook/preview.js
+++ b/example/.storybook/preview.js
@@ -1,7 +1,7 @@
 import { addDecorator, addParameters } from '@storybook/react';
 import { withPlayroom } from 'storybook-addon-playroom';
 
-addDecorator(withPlayroom);
+addDecorator(withPlayroom); // before any other decorators
 
 addParameters({
   playroom: {


### PR DESCRIPTION
This PR updates the `./storybook/preview.js` example code block in the `README.md` and `./example` directory to add a comment about loading the decorator before any others.