### PR TITLE
feat: allow custom react-element-to-jsx-string options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ See [`example`](example) for a minimal working setup.
 
 The addon can be configured globally and per story with the `playroom` parameter. The following options are available:
 
-| Option     | Description                          | Default                 |
-|:-----------|:-------------------------------------|:------------------------|
-| `url`      | the Playroom URL                     | `http://localhost:9000` |
-| `disabled` | whether to disable the addon         | `false`                 |
+| Option                           | Description                              | Default                 |
+|:---------------------------------|:-----------------------------------------|:------------------------|
+| `url`                            | the Playroom URL                         | `http://localhost:9000` |
+| `disabled`                       | whether to disable the addon             | `false`                 |
+| `reactElementToJSXStringOptions` | [react-element-to-jsx-string options][1] | `{ sortProps: false }`  |
 
 ### Global configuration
 
@@ -82,3 +83,5 @@ myStory.story = {
   },
 };
 ```
+
+[1]: https://github.com/algolia/react-element-to-jsx-string#reactelementtojsxstringreactelement-options

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,11 +21,12 @@ const Story: FC<Props> = ({
     parameters: {
       url = 'http://localhost:9000',
       disabled = false,
+      reactElementToJSXStringOptions = { sortProps: false },
     } = {},
   },
 }) => {
   const story = getStory(context);
-  const jsxString = reactElementToJSXString(story);
+  const jsxString = reactElementToJSXString(story, reactElementToJSXStringOptions);
   const channel = addons.getChannel();
   const codeUrl = url && `${url}#?code=${base64Url.encode(jsxString)}`;
 


### PR DESCRIPTION
Allow defining custom [react-element-to-jsx-string options](https://github.com/algolia/react-element-to-jsx-string#reactelementtojsxstringreactelement-options) via a `reactElementToJSXStringOptions` parameter option.

Closes #7.