### PR TITLE
feat(code)!: exclude global decorators by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ export default {
 
 The addon can be configured via the `playroom` [parameter](https://storybook.js.org/docs/react/writing-stories/parameters). The following options are available:
 
-| Option                           | Type      | Description                              | Default                 |
-| :------------------------------- | :-------- | :--------------------------------------- | :---------------------- |
-| `url`                            | `string`  | the Playroom URL                         | `http://localhost:9000` |
-| `code`                           | `string`  | code to be used instead of story source  |                         |
-| `disable`                        | `boolean` | whether to disable the addon             | `false`                 |
-| `reactElementToJSXStringOptions` | `object`  | [react-element-to-jsx-string options][1] | `{ sortProps: false }`  |
+| Option                           | Type      | Description                                       | Default                 |
+| :------------------------------- | :-------- | :------------------------------------------------ | :---------------------- |
+| `url`                            | `string`  | the Playroom URL                                  | `http://localhost:9000` |
+| `code`                           | `string`  | code to be used instead of story source           |                         |
+| `disable`                        | `boolean` | whether to disable the addon                      | `false`                 |
+| `omitCodeDecorators`             | `boolean` | whether to omit global decorators in stories code | `false`                 |
+| `reactElementToJSXStringOptions` | `object`  | [react-element-to-jsx-string options][1]          | `{ sortProps: false }`  |
 
 To configure for all stories, set the `playroom` parameter in [`.storybook/preview.js`](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering):
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ export default {
 
 The addon can be configured via the `playroom` [parameter](https://storybook.js.org/docs/react/writing-stories/parameters). The following options are available:
 
-| Option                           | Type      | Description                                       | Default                 |
-| :------------------------------- | :-------- | :------------------------------------------------ | :---------------------- |
-| `url`                            | `string`  | the Playroom URL                                  | `http://localhost:9000` |
-| `code`                           | `string`  | code to be used instead of story source           |                         |
-| `disable`                        | `boolean` | whether to disable the addon                      | `false`                 |
-| `omitCodeDecorators`             | `boolean` | whether to omit global decorators in stories code | `false`                 |
-| `reactElementToJSXStringOptions` | `object`  | [react-element-to-jsx-string options][1]          | `{ sortProps: false }`  |
+| Option                           | Type      | Description                                          | Default                 |
+| :------------------------------- | :-------- | :--------------------------------------------------- | :---------------------- |
+| `url`                            | `string`  | the Playroom URL                                     | `http://localhost:9000` |
+| `code`                           | `string`  | code to be used instead of story source              |                         |
+| `disable`                        | `boolean` | whether to disable the addon                         | `false`                 |
+| `includeDecorators`              | `boolean` | whether to include global decorators in stories code | `false`                 |
+| `reactElementToJSXStringOptions` | `object`  | [react-element-to-jsx-string options][1]             | `{ sortProps: false }`  |
 
 To configure for all stories, set the `playroom` parameter in [`.storybook/preview.js`](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering):
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -4,6 +4,7 @@ type Options = {
   url?: string
   code?: string
   disable?: boolean
+  omitCodeDecorators?: boolean
   reactElementToJSXStringOptions?: ReactElementToJSXStringOptions
 }
 
@@ -11,10 +12,12 @@ export const getOptions = ({
   url = 'http://localhost:9000',
   code = '',
   disable = false,
+  omitCodeDecorators = false,
   reactElementToJSXStringOptions = { sortProps: false },
 }: Options = {}): Required<Options> => ({
   url,
   code,
   disable,
+  omitCodeDecorators,
   reactElementToJSXStringOptions,
 })

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -4,7 +4,7 @@ type Options = {
   url?: string
   code?: string
   disable?: boolean
-  omitCodeDecorators?: boolean
+  includeDecorators?: boolean
   reactElementToJSXStringOptions?: ReactElementToJSXStringOptions
 }
 
@@ -12,12 +12,12 @@ export const getOptions = ({
   url = 'http://localhost:9000',
   code = '',
   disable = false,
-  omitCodeDecorators = false,
+  includeDecorators = false,
   reactElementToJSXStringOptions = { sortProps: false },
 }: Options = {}): Required<Options> => ({
   url,
   code,
   disable,
-  omitCodeDecorators,
+  includeDecorators,
   reactElementToJSXStringOptions,
 })

--- a/src/withGlobals.ts
+++ b/src/withGlobals.ts
@@ -17,12 +17,13 @@ export const withGlobals = (
 ) => {
   const { parameters, undecoratedStoryFn } = context
   const playroomConfig = parameters[PARAM_KEY]
-  const { url, code, omitCodeDecorators, reactElementToJSXStringOptions } =
+  const { url, code, includeDecorators, reactElementToJSXStringOptions } =
     getOptions(playroomConfig)
   const story = StoryFn() as ReactElement
-  const storyCode = omitCodeDecorators
-    ? (undecoratedStoryFn(context) as ReactElement)
-    : story
+  const storyCode = includeDecorators
+    ? story
+    : (undecoratedStoryFn(context) as ReactElement)
+
   const jsxString =
     code || reactElementToJSXString(storyCode, reactElementToJSXStringOptions)
   const codeUrl = url && createUrl({ baseUrl: url, code: jsxString })

--- a/src/withGlobals.ts
+++ b/src/withGlobals.ts
@@ -15,13 +15,16 @@ export const withGlobals = (
   StoryFn: StoryFunction<Renderer>,
   context: StoryContext<Renderer>,
 ) => {
-  const { parameters } = context
+  const { parameters, undecoratedStoryFn } = context
   const playroomConfig = parameters[PARAM_KEY]
-  const { url, code, reactElementToJSXStringOptions } =
+  const { url, code, omitCodeDecorators, reactElementToJSXStringOptions } =
     getOptions(playroomConfig)
   const story = StoryFn() as ReactElement
+  const storyCode = omitCodeDecorators
+    ? (undecoratedStoryFn(context) as ReactElement)
+    : story
   const jsxString =
-    code || reactElementToJSXString(story, reactElementToJSXStringOptions)
+    code || reactElementToJSXString(storyCode, reactElementToJSXStringOptions)
   const codeUrl = url && createUrl({ baseUrl: url, code: jsxString })
 
   const emit = useChannel({})


### PR DESCRIPTION
Introduces the `omitCodeDecorators` configuration option to fix the issue with adding unnecessary decorators to Playroom code.

Issue: https://github.com/rbardini/storybook-addon-playroom/issues/47