### PR TITLE
ci(workflow): use `.nvmrc` as single source for node

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
 
       - name: Install
         run: npm ci


### PR DESCRIPTION

Hey @rbardini, 

Noticed you updated node version recently and thought about updating  the actions/setup-node GH action to read the node version directly from the .nvmrc file.

This will guarantee that the versions will be updated in future iterations only in a single place. 

Cheers ❤️